### PR TITLE
Feat/mediator: Implement Module Mediator Pattern for Decoupled Inter-Module Communication

### DIFF
--- a/app.moon
+++ b/app.moon
@@ -1,47 +1,24 @@
----
--- Require LuaRocks / lapis packages
 lapis = require "lapis"
 lfs = require "lfs"
 
----
--- Require NaxxramasCMS packages
 require "system.module_loader"
 require "system.base_controller"
+require "system.module_mediator"
 
----
--- Singleton
 module_loader = System.ModuleLoader\get_instance!
 
----
--- Application class extending lapis.Application
--- Provides handlers for 404 and 500 errors
 class Application extends lapis.Application
-    ---
-    -- Handler for 404 errors
-    -- @return nil
-    handle_404: =>
-        return nil
+    handle_404: => nil
+    handle_500: (err, trace) => nil
 
-  ---
-  -- Handler for 500 errors
-  -- @param err A description of the error
-  -- @param trace The error trace if available
-  -- @return nil
-    handle_500: (err, trace) =>
-        return nil
-
----
--- Sets up and initializes an application instance
--- @return The configured application instance
 SetupApplicationInstance = ->
     application = Application!
-
     application\enable "etlua"
+
     application.html = require "lapis.html"
     application.layout = require "applications.themes.default.layout"
-
+    
     module_loader\load application, "applications/modules"
-
     return application
 
 SetupApplicationInstance!

--- a/applications/modules/home/controller/home_controller.moon
+++ b/applications/modules/home/controller/home_controller.moon
@@ -1,9 +1,14 @@
 HomeView = require "applications.modules.home.view.index"
-NewsController = require "applications.modules.news.controller.news_controller"
+
+mediator = System.ModuleMediator\get_instance!
 
 class HomeController extends System.BaseController
+    @\action "index"
+    
     index: (application) =>
-        news_widget_data = NewsController.latest application, {
+        mediator = @get_mediator!
+        
+        news_widget_data = mediator\request "news", "latest", application, {
             limit: 3
             title: "Dernières actualités"
             show_date: true
@@ -20,9 +25,4 @@ class HomeController extends System.BaseController
 
         return @render_view HomeView
 
-controller = HomeController!
-
-return {
-    index: (application) ->
-        controller\index application
-}
+HomeController!\register_as "home"

--- a/applications/modules/home/router.moon
+++ b/applications/modules/home/router.moon
@@ -1,12 +1,9 @@
 app_respond_to = require("lapis.application").respond_to
 
-controller = require "applications.modules.home.controller.home_controller"
+mediator = System.ModuleMediator\get_instance!
 
---- Declares routes for the `home` module.
--- Mounts the `home_controller` controller on the root `/` of the module.
--- @param self Lapis Application Instance, used to declare routes via `@\match`.
--- @see applications.modules.home.controller.home_controller
 return (self) -> 
     @\match "/", app_respond_to {
-        GET: controller.index
+        GET: (app) ->
+            mediator\request "home", "index", app
     }

--- a/applications/modules/news/controller/news_controller.moon
+++ b/applications/modules/news/controller/news_controller.moon
@@ -39,6 +39,9 @@ news_list = {
 }
 
 class NewsController extends System.BaseController
+    @\action "latest"
+    @\action "index"
+
     latest: (application, options = {}) =>
         limit = options.limit or 1
         
@@ -63,12 +66,4 @@ class NewsController extends System.BaseController
 
         return @render_view NewsListIndex
 
-news_controller = NewsController!
-
-return {
-    index: (application) ->
-        news_controller\index application
-
-    latest: (application, options) ->
-        news_controller\latest application, options
-}
+NewsController!\register_as "news"

--- a/applications/modules/news/router.moon
+++ b/applications/modules/news/router.moon
@@ -1,8 +1,9 @@
 app_respond_to = require("lapis.application").respond_to
 
-controller = require "applications.modules.news.controller.news_controller"
+mediator = System.ModuleMediator\get_instance!
 
 return (self) -> 
     @\match "/news", app_respond_to {
-        GET: controller.index
+        GET: (app) ->
+            mediator\request "news", "index", app
     }

--- a/system/module_loader.moon
+++ b/system/module_loader.moon
@@ -10,6 +10,37 @@ class ModuleLoader
         return @@instance
 
     load: (application, path) =>
+        @load_controllers path
+        @load_routers application, path
+
+    load_controllers: (path) =>
+        for element in lfs.dir path
+            continue if element == "." or element == ".."
+
+            full_path = "#{path}/#{element}"
+            attributes = lfs.attributes full_path
+
+            continue unless attributes and attributes.mode == "directory"
+
+            controller_path = "#{full_path}/controller"
+            controller_attributes = lfs.attributes controller_path
+            
+            if controller_attributes and controller_attributes.mode == "directory"
+                @load_module_controller controller_path, element
+
+    load_module_controller: (controller_path, module_name) =>
+        main_controller_file = "#{module_name}_controller.lua"
+        controller_file_path = "#{controller_path}/#{main_controller_file}"
+        
+        if lfs.attributes controller_file_path
+            controller_path_sanitized = controller_file_path\gsub("[/\\]", ".")\gsub("%.lua$", "")
+            
+            success, controller_module = pcall require, controller_path_sanitized
+            
+            unless success
+                error "Failed to load controller for module #{module_name}: #{controller_module}"
+
+    load_routers: (application, path) =>        
         for element in lfs.dir path
             continue if element == "." or element == ".."
 
@@ -28,4 +59,4 @@ class ModuleLoader
             if success and type(router) == "function"
                 router application
             else
-                error "Failed to load module: #{element}"
+                error "Failed to load router for module: #{element}"

--- a/system/module_mediator.moon
+++ b/system/module_mediator.moon
@@ -1,0 +1,61 @@
+module "System", package.seeall
+export ModuleMediator
+
+class ModuleMediator
+    @instance = nil
+    
+    new: =>
+        @handlers = {}
+        @modules = {}
+    
+    @get_instance: =>
+        unless @@instance
+            @@instance = ModuleMediator!
+        return @@instance
+    
+    register_module: (module_name, module_handlers) =>
+        @modules[module_name] = module_handlers
+        
+        for action, handler in pairs module_handlers
+            key = "#{module_name}.#{action}"
+            @handlers[key] = handler
+    
+    request: (module_name, action, application, params = {}) =>
+        key = "#{module_name}.#{action}"
+        handler = @handlers[key]
+        
+        unless handler
+            return {
+                status: 404
+                json: { error: "Handler not found: #{key}" }
+            }
+        
+        success, result = pcall handler, application, params
+        
+        unless success
+            return {
+                status: 500
+                json: { error: "Handler execution failed: #{result}" }
+            }
+        
+        return result
+    
+    has_handler: (module_name, action) =>
+        key = "#{module_name}.#{action}"
+        return @handlers[key] != nil
+    
+    get_registered_modules: =>
+        modules = {}
+        for name, _ in pairs @modules
+            table.insert modules, name
+        return modules
+    
+    get_module_actions: (module_name) =>
+        actions = {}
+        module_handlers = @modules[module_name]
+        
+        if module_handlers
+            for action, _ in pairs module_handlers
+                table.insert actions, action
+        
+        return actions


### PR DESCRIPTION
# Module Mediator Pattern Implementation

## Overview
Introduces a mediator pattern to decouple inter-module communication, replacing direct controller dependencies with centralized routing.

## Problem
- Home controller directly imported News controller (`require "applications.modules.news.controller.news_controller"`)
- Tight coupling between modules violates HMVC principles

## Solution
**Module Mediator Pattern** with **Registry-based Action Declaration**

### Key Components
- **ModuleMediator**: Singleton for centralized module communication
- **Enhanced BaseController**: `@\action` decorator + `register_as()` method
- **Updated Controllers**: Explicit action declaration with auto-registration
- **Updated Routers**: Direct mediator requests instead of controller imports

## Changes

### Before
```lua
NewsController = require "applications.modules.news.controller.news_controller"
news_data = NewsController.latest application, options
```

### After
```lua
class HomeController extends System.BaseController
    @\action "index"
    
    index: (application) =>
        mediator = @get_mediator!
        news_data = mediator\request "news", "latest", application, options

HomeController!\register_as "home"
```

## Benefits
- ✅ Decoupled module architecture
- ✅ HMVC compliance
- ✅ Explicit action declaration prevents accidental exposure
- ✅ Centralized error handling
- ✅ Easy module addition/removal

## Breaking Changes
- Controllers must use `@\action "method_name"` for public methods
- Routers use `mediator\request` instead of controller imports
- Remove manual handler exports