### PR TITLE
Fix/news page

### DIFF
--- a/applications/themes/default/assets/widgets/card_home.etlua
+++ b/applications/themes/default/assets/widgets/card_home.etlua
@@ -6,10 +6,13 @@
 
             <!-- Main Image -->
             <img
-                src="https://bnetcmsus-a.akamaihd.net/cms/blog_header/e8/E8WQFI083QTW1738635431840.png"
+                src="<%= news:get_image() %>"
                 alt="Screenshot from World of Warcraft"
                 class="w-full h-full object-cover group-hover:scale-110 transition-transform duration-500"
             >
+
+            <!-- Shadow Gradient Overlay -->
+            <div class="absolute inset-0 bg-gradient-to-t from-black/100 via-black/20 to-transparent"></div>
 
             <!-- Content Overlay -->
             <div class="absolute inset-0 flex flex-col justify-between p-4 z-10">
@@ -19,7 +22,7 @@
                 <!-- Bottom Content -->
                 <div class="space-y-3">
                     <!-- Date -->
-                    <time class="text-[#7E7E7E]" datetime="<%= news:get_created_at() %>">
+                    <time class="text-[#fff]" datetime="<%= news:get_created_at() %>">
                         <%= news:get_created_at() %>
                     </time>
 

--- a/applications/themes/default/assets/widgets/card_news.etlua
+++ b/applications/themes/default/assets/widgets/card_news.etlua
@@ -2,11 +2,11 @@
     <a href="/news/<%= news:get_slug() %>" class="relative w-full">
 
         <!-- Card Container -->
-        <div class="relative w-full h-[250px] py-4 pr-10 pl-[460px] bg-[#191413] outline outline-gray-700 hover:outline hover:outline-[#EBA309]">
+        <div class="relative w-full h-[250px] py-4 pr-10 pl-[460px] my-2 bg-[#191413] outline outline-gray-700 hover:outline hover:outline-[#EBA309]">
 
             <!-- News Image -->
             <img
-                src="https://bnetcmsus-a.akamaihd.net/cms/blog_header/e8/E8WQFI083QTW1738631840.png"
+                src="<%= news:get_image() %>"
                 alt="Thumbnail of the news article"
                 class="absolute left-0 top-0 h-[250px] w-auto"
             />

--- a/applications/themes/default/assets/widgets/card_news.etlua
+++ b/applications/themes/default/assets/widgets/card_news.etlua
@@ -2,7 +2,7 @@
     <a href="/news/<%= news:get_slug() %>" class="relative w-full">
 
         <!-- Card Container -->
-        <div class="relative w-full h-[250px] py-4 pr-4 pl-[460px] bg-[#191413] outline outline-gray-700 hover:outline hover:outline-[#EBA309]">
+        <div class="relative w-full h-[250px] py-4 pr-10 pl-[460px] bg-[#191413] outline outline-gray-700 hover:outline hover:outline-[#EBA309]">
 
             <!-- News Image -->
             <img
@@ -17,8 +17,13 @@
                 <h2 class="text-2xl pb-3 font-semibold text-yellow-500"><%= news:get_title() %></h2>
 
                 <!-- Description -->
-                <p class="mt-2 text-md text-neutral-400">
-                    <%- news:get_content() %>
+                <p class="mt-2 text-md text-neutral-400 overflow-hidden">
+                    <% local content = news:get_content() or "" %>
+                    <% if #content > 50 then %>
+                        <%- content:sub(1, 350) %>...
+                    <% else %>
+                        <%- content %>
+                    <% end %>
                 </p>
             </div>
 


### PR DESCRIPTION
This pull request introduces several improvements to the news section and card components, focusing on dynamic content rendering, visual enhancements, and smoother navigation. The most significant changes include dynamic image sourcing for news cards, improved content truncation, visual overlays for better readability, and the addition of smooth scrolling behavior when navigating to the news section.

**News Card and Content Improvements**
* News card images now use the dynamic value from `news:get_image()` instead of a hardcoded URL, ensuring each card displays the correct image. (`card_home.etlua`, `card_news.etlua`) [[1]](diffhunk://#diff-5802704dd1a996a891f1435243803ab00d59e152a8b00fd1726def9d3fc79458L9-R16) [[2]](diffhunk://#diff-d4bc1086874e2806a2f9c7ddead13df436152b770e0f21bd2ee953fceef8e2f2L5-R9)
* News card descriptions are truncated to 350 characters if the content is longer than 50 characters, providing a cleaner preview and preventing overflow. (`card_news.etlua`)

**Visual and UI Enhancements**
* A shadow gradient overlay is added to the main news card image, improving text readability and overall aesthetics. (`card_home.etlua`)
* The date text color on the news card is changed from gray to white for better visibility. (`card_home.etlua`)
* Minor layout adjustments, such as increased right padding and vertical margin on news cards, enhance spacing and alignment. (`card_news.etlua`)

**Navigation and Smooth Scrolling**
* The "News" navigation link now points to `/news#news-section` and includes the `scroll-smooth` class, enabling smooth scrolling to the news section. (`nav.etlua`)
* The news section is given an `id="news-section"` to serve as a scroll target for anchor navigation. (`index.etlua`)
* A new `smooth.js` script is introduced and loaded, which handles smooth scrolling to anchor targets and updates the URL hash for a seamless user experience. (`smooth.js`, `layout.etlua`) [[1]](diffhunk://#diff-13ad4cb4a25defe9e0fc42cb4625b73e69fd43bfd41eb1d57650a2c07df183fcR1-R27) [[2]](diffhunk://#diff-2093b2c0595d4aed6a73834c2ee40c0599393cdb842b3e3b5341f47628027f6dR21)